### PR TITLE
feat: implement v3.2 setlist enhancements

### DIFF
--- a/dnbSetlist_V3I1.jsx
+++ b/dnbSetlist_V3I1.jsx
@@ -132,7 +132,7 @@ export default function App() {
   const lastClipEnd = useMemo(()=> Math.max(0, ...clips.map(c => c.endSec || 0)), [clips]);
   const maxEnd = Math.max(120, mediaDurationSec || 0, lastClipEnd) + DEFAULT_TAIL_PADDING_SEC;
   const timelineWidthPx = Math.ceil(maxEnd * pxPerSec) + 300;
-  const containerRef = useRef(null);
+  const timelineRef = useRef(null);
 
   // playhead + player refs
   const [playheadSec, setPlayheadSec] = useState(0);
@@ -144,7 +144,7 @@ export default function App() {
   const lastRAF = useRef(null);
 
   useEffect(()=>{
-    const el = containerRef.current;
+    const el = timelineRef.current;
     if (!el) return;
     const onWheel = (e) => {
       if (e.ctrlKey) {
@@ -390,8 +390,16 @@ export default function App() {
 
   const playPauseRef = useRef(playPauseToggle);
   playPauseRef.current = playPauseToggle;
+  const deleteRef = useRef(() => {});
+  deleteRef.current = () => {
+    if (selectedMarkerRef) deleteMarker(selectedMarkerRef.clipId, selectedMarkerRef.markerId);
+    else if (selectedClipId) deleteClip(selectedClipId);
+  };
   useEffect(() => {
-    const onKey = (e) => { if (e.code === 'Space') { e.preventDefault(); playPauseRef.current(); } };
+    const onKey = (e) => {
+      if (e.code === 'Space') { e.preventDefault(); playPauseRef.current(); }
+      else if (e.key === 'Delete') { e.preventDefault(); deleteRef.current(); }
+    };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, []);
@@ -410,29 +418,29 @@ export default function App() {
   const [hover, setHover] = useState(null);
 
   return (
-    <div className="h-screen p-4 bg-slate-50 text-slate-900 flex flex-col overflow-hidden" ref={containerRef}>
-      <header className="flex items-center justify-between mb-3 flex-shrink-0">
-        <h1 className="text-2xl font-bold">DnB Live Set Timeline (v3.2)</h1>
-        <div className="flex gap-2 items-center">
-          <input placeholder="YouTube or SoundCloud URL" id="media-url" className="px-2 py-1 border rounded" onBlur={(e)=> attachPlayer(e.target.value)} />
-          <div id="player-container" style={{ width:200 }} />
-          <button onClick={playPauseToggle} className="px-3 py-1 rounded bg-slate-900 text-white">{playing ? 'Pause' : 'Play'}</button>
-          <button onClick={()=> seekTo(0)} className="px-2 py-1 rounded bg-white border">Reset Playhead</button>
-          <button onClick={exportJSON} className="px-3 py-1 rounded bg-slate-900 text-white">Export JSON</button>
-          <button onClick={exportCSV} className="px-3 py-1 rounded bg-slate-900 text-white">Export CSV</button>
-          <label className="px-3 py-1 bg-white border rounded cursor-pointer">Import JSON<input type="file" accept="application/json" className="hidden" onChange={e=> { const f = e.target.files?.[0]; if (f) importJSON(f); }} /></label>
-          <label className="px-3 py-1 bg-white border rounded cursor-pointer">Import Setlist<input type="file" accept="text/plain" className="hidden" onChange={e=> { const f=e.target.files?.[0]; if(f) importYTSetlist(f); }} /></label>
-          <button onClick={clearAllClips} className="px-3 py-1 rounded bg-white border">Clear Clips</button>
+    <div className="h-screen p-2 bg-slate-50 text-slate-900 flex flex-col overflow-hidden" onMouseDown={() => { setSelectedClipId(null); setSelectedMarkerRef(null); }}>
+      <header className="flex items-center justify-between mb-1 flex-shrink-0 text-xs">
+        <h1 className="text-lg font-bold">DnB Live Set Timeline (v3.2)</h1>
+        <div className="flex gap-1 items-center">
+          <input placeholder="YouTube or SoundCloud URL" id="media-url" className="px-1 py-0.5 border rounded text-xs" onBlur={(e)=> attachPlayer(e.target.value)} />
+          <div id="player-container" style={{ width:150 }} />
+          <button onClick={playPauseToggle} className="px-2 py-1 rounded bg-slate-900 text-white text-xs">{playing ? 'Pause' : 'Play'}</button>
+          <button onClick={()=> seekTo(0)} className="px-2 py-1 rounded bg-white border text-xs">Reset</button>
+          <button onClick={exportJSON} className="px-2 py-1 rounded bg-slate-900 text-white text-xs">Export JSON</button>
+          <button onClick={exportCSV} className="px-2 py-1 rounded bg-slate-900 text-white text-xs">Export CSV</button>
+          <label className="px-2 py-1 bg-white border rounded cursor-pointer text-xs">Import JSON<input type="file" accept="application/json" className="hidden" onChange={e=> { const f = e.target.files?.[0]; if (f) importJSON(f); }} /></label>
+          <label className="px-2 py-1 bg-white border rounded cursor-pointer text-xs">Import Setlist<input type="file" accept="text/plain" className="hidden" onChange={e=> { const f=e.target.files?.[0]; if(f) importYTSetlist(f); }} /></label>
+          <button onClick={clearAllClips} className="px-2 py-1 rounded bg-white border text-xs">Clear</button>
         </div>
         {mediaInfo.title && (
-          <div className="text-xs text-right ml-4">
+          <div className="text-[10px] text-right ml-2">
             <div className="font-semibold">{mediaInfo.title}</div>
             <div>{fmtTime(playheadSec)} / {fmtTime(Math.max(mediaDurationSec - playheadSec,0))} left</div>
           </div>
         )}
       </header>
 
-      <div className="bg-white rounded p-3 shadow overflow-x-auto overflow-y-hidden flex-1">
+      <div ref={timelineRef} className="bg-white rounded p-2 shadow overflow-x-auto overflow-y-hidden flex-1">
         {/* Big overall timeline integrated above the tracks */}
         <div style={{ width: timelineWidthPx }} className="mb-2">
           <BigTimelineHeader
@@ -480,7 +488,7 @@ export default function App() {
         </div>
       </div>
 
-      <div className="mb-3 flex items-center gap-2 flex-shrink-0">
+      <div className="mb-2 flex items-center gap-2 flex-shrink-0">
         <Legend subtypes={subtypes} subtypeTypes={subtypeTypes} onAddSubtype={addSubtype} onUpdateSubtype={updateSubtype} onDeleteSubtype={deleteSubtype} />
       </div>
 
@@ -574,32 +582,32 @@ function Legend({ subtypes, subtypeTypes, onAddSubtype, onUpdateSubtype, onDelet
   const markerNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'transition' || subtypeTypes[k] === 'effect');
   const markerItems = markerNames.map(n => ({ name: n, type: subtypeTypes[n] || 'transition' }));
   return (
-    <div className="relative w-full border rounded p-3">
-      <button className="absolute top-2 right-2 text-xs underline" onClick={()=> setManage(m=>!m)}>{manage? 'Close':'Manage'}</button>
-      <div className="flex items-start text-sm w-full">
-        <div className="pr-4">
+    <div className="relative w-full border rounded p-2 text-xs">
+      <button className="absolute top-1 right-1 text-[10px] underline" onClick={()=> setManage(m=>!m)}>{manage? 'Close':'Manage'}</button>
+      <div className="flex items-start w-full">
+        <div className="pr-3">
           <div className="font-semibold">Clips (Subgenre)</div>
-          <div className="flex gap-2 mt-1 flex-wrap">{clipNames.map(name => (
-            <div key={name} className="flex items-center gap-1"><div style={{width:12,height:12,background: subtypes[name],borderRadius:3}}/><div className="text-xs">{name}</div></div>
+          <div className="flex gap-1 mt-1 flex-wrap">{clipNames.map(name => (
+            <div key={name} className="flex items-center gap-1"><div style={{width:10,height:10,background: subtypes[name],borderRadius:2}}/><div className="text-[10px]">{name}</div></div>
           ))}</div>
         </div>
-        <div className="px-4 border-l">
+        <div className="px-3 border-l">
           <div className="font-semibold">Markers (Subtypes)</div>
-          <div className="flex gap-3 flex-wrap items-center mt-1">
+          <div className="flex gap-2 flex-wrap items-center mt-1">
             {markerItems.map(({name,type}) => (
-              <div key={name} className="flex items-center gap-2 border px-2 py-1 rounded">
+              <div key={name} className="flex items-center gap-1.5 border px-1.5 py-0.5 rounded">
                 {type === 'effect'
-                  ? <div style={{ width: 0, height: 0, borderLeft: '7px solid transparent', borderRight: '7px solid transparent', borderBottom: `12px solid ${subtypes[name]}` }} />
-                  : <div style={{width:14,height:14,background: subtypes[name],borderRadius:3}} />}
-                <div className="text-xs">{name}</div>
+                  ? <div style={{ width: 0, height: 0, borderLeft: '6px solid transparent', borderRight: '6px solid transparent', borderBottom: `10px solid ${subtypes[name]}` }} />
+                  : <div style={{width:12,height:12,background: subtypes[name],borderRadius:2}} />}
+                <div className="text-[10px]">{name}</div>
               </div>
             ))}
           </div>
         </div>
-        <div className="pl-4 border-l">
+        <div className="pl-3 border-l">
           <div className="font-semibold">Remix (Striped)</div>
-          <div className="flex gap-2 mt-1 flex-wrap">{remixNames.map(name => (
-            <div key={name} className="flex items-center gap-1"><div style={{width:12,height:12,background: subtypes[name] ? `repeating-linear-gradient(45deg, ${subtypes[name]}, ${subtypes[name]} 6px, #fff 6px, #fff 12px)` : '#fff', border:'1px solid #ddd', borderRadius:3}}/><div className="text-xs">{name}</div></div>
+          <div className="flex gap-1 mt-1 flex-wrap">{remixNames.map(name => (
+            <div key={name} className="flex items-center gap-1"><div style={{width:10,height:10,background: subtypes[name] ? `repeating-linear-gradient(45deg, ${subtypes[name]}, ${subtypes[name]} 6px, #fff 6px, #fff 12px)` : '#fff', border:'1px solid #ddd', borderRadius:2}}/><div className="text-[10px]">{name}</div></div>
           ))}</div>
         </div>
       </div>
@@ -686,16 +694,15 @@ function SubtypeManager({ subtypes, subtypeTypes, onAdd, onUpdate, onDelete }) {
 
 function TrackRow({ children, trackIndex, widthPx, pxPerBeat, onAdd }) {
   return (
-    <div className="mb-3">
-      <div className="flex items-center gap-2 mb-1">
-        <div className="px-2 py-0.5 bg-slate-800 text-white rounded text-xs">Deck {trackIndex+1}</div>
+    <div className="mb-1">
+      <div className="flex items-center gap-2 mb-0.5">
+        <div className="px-1.5 py-0.5 bg-slate-800 text-white rounded text-xs">Deck {trackIndex+1}</div>
       </div>
-      <div id={`track-${trackIndex}`} className="relative h-24 rounded-xl border overflow-visible" style={{ width: widthPx }}>
+      <div id={`track-${trackIndex}`} className="relative h-20 rounded-lg border overflow-visible" style={{ width: widthPx }}>
         <GridBackground pxPerBeat={pxPerBeat} />
         {children}
         <button
-          className="sticky top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-white border shadow flex items-center justify-center text-lg"
-          style={{ left: 'calc(100% - 2rem)' }}
+          className="sticky right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full bg-white border shadow flex items-center justify-center text-base"
           onClick={onAdd}
         >
           +
@@ -803,24 +810,23 @@ function Inspector({ clip, selectedMarkerRef, onChange, onDelete, onAddMarker, o
   function updateField(field, value) { setDraft(d=> ({ ...d, [field]: value })); if (selectedMarkerRef) { const patch = { [field]: value }; if (field === 'startSec' || field === 'endSec') { patch[field] = value === '' || value == null ? undefined : Number(value); } onUpdateMarker(selectedMarkerRef.clipId, selectedMarkerRef.markerId, patch); } }
 
   return (
-    <div className="mt-4 p-4 bg-white rounded shadow grid grid-cols-2 gap-6">
+    <div className="mt-2 p-2 bg-white rounded shadow grid grid-cols-2 gap-4 text-xs" onMouseDown={(e)=> e.stopPropagation()}>
       <div>
-        <div className="text-lg font-semibold mb-2">Clip Inspector</div>
-        
-<div className="grid grid-cols-2 gap-2 text-sm">
-          <label className="flex items-center gap-2 col-span-2"><span className="w-28">Name</span><input className="flex-1 px-2 py-1 border rounded" value={clip.name} onChange={(e)=> onChange({ name: e.target.value })} /></label>
-          <label className="flex items-center gap-2"><span className="w-28">Deck</span><select className="flex-1 px-2 py-1 border rounded" value={clip.track} onChange={(e)=> onChange({ track: Number(e.target.value) })}>{Array.from({length:4}).map((_,i)=><option key={i} value={i}>Deck {i+1}</option>)}</select></label>
-          <label className="flex items-center gap-2"><span className="w-28">Camelot</span><input className="flex-1 px-2 py-1 border rounded" value={clip.camelot||''} onChange={(e)=> onChange({ camelot: e.target.value })} /></label>
-          <label className="flex items-center gap-2"><span className="w-28">Subgenre</span><select className="flex-1 px-2 py-1 border rounded" value={clip.subgenre||''} onChange={(e)=> onChange({ subgenre: e.target.value })}><option value="">(custom)</option>{Object.keys(subtypes).filter(k=> subtypeTypes[k]==='clip').map(k=> <option key={k} value={k}>{k}</option>)}</select></label>
-          <label className="flex items-center gap-2"><span className="w-28">Remix</span><select className="flex-1 px-2 py-1 border rounded" value={clip.remixType} onChange={(e)=> onChange({ remixType: e.target.value })}>{Object.keys(subtypes).filter(k=> subtypeTypes[k]==='remix').map(k => <option key={k} value={k}>{k}</option>)}</select></label>
-          <label className="flex items-center gap-2"><span className="w-28">Energy</span><input type="number" className="flex-1 px-2 py-1 border rounded" value={clip.energy||5} onChange={(e)=> onChange({ energy: Math.max(1, Math.min(10, Math.round(Number(e.target.value)))) })} /></label>
+        <div className="text-sm font-semibold mb-1">Clip Inspector</div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <label className="flex items-center gap-2 col-span-2"><span className="w-24">Name</span><input className="flex-1 px-1 py-0.5 border rounded" value={clip.name} onChange={(e)=> onChange({ name: e.target.value })} /></label>
+          <label className="flex items-center gap-2"><span className="w-24">Deck</span><select className="flex-1 px-1 py-0.5 border rounded" value={clip.track} onChange={(e)=> onChange({ track: Number(e.target.value) })}>{Array.from({length:4}).map((_,i)=><option key={i} value={i}>Deck {i+1}</option>)}</select></label>
+          <label className="flex items-center gap-2"><span className="w-24">Camelot</span><input className="flex-1 px-1 py-0.5 border rounded" value={clip.camelot||''} onChange={(e)=> onChange({ camelot: e.target.value })} /></label>
+          <label className="flex items-center gap-2"><span className="w-24">Subgenre</span><select className="flex-1 px-1 py-0.5 border rounded" value={clip.subgenre||''} onChange={(e)=> onChange({ subgenre: e.target.value })}><option value="">(custom)</option>{Object.keys(subtypes).filter(k=> subtypeTypes[k]==='clip').map(k=> <option key={k} value={k}>{k}</option>)}</select></label>
+          <label className="flex items-center gap-2"><span className="w-24">Remix</span><select className="flex-1 px-1 py-0.5 border rounded" value={clip.remixType} onChange={(e)=> onChange({ remixType: e.target.value })}>{Object.keys(subtypes).filter(k=> subtypeTypes[k]==='remix').map(k => <option key={k} value={k}>{k}</option>)}</select></label>
+          <label className="flex items-center gap-2"><span className="w-24">Energy</span><input type="number" className="flex-1 px-1 py-0.5 border rounded" value={clip.energy||5} onChange={(e)=> onChange({ energy: Math.max(1, Math.min(10, Math.round(Number(e.target.value)))) })} /></label>
         </div>
-        <div className="mt-3">
-<button className="px-3 py-1 bg-rose-600 text-white rounded" onClick={()=> onDelete()}>Delete Clip</button></div>
+        <div className="mt-2"><button className="px-2 py-1 bg-rose-600 text-white rounded" onClick={()=> onDelete()}>Delete Clip</button></div>
       </div>
 
       <div>
-        <div className="text-lg font-semibold mb-2">Markers (seconds)</div>
+        <div className="text-sm font-semibold mb-1">Markers (seconds)</div>
         <MarkerEditor
           clip={clip}
           selectedMarkerRef={selectedMarkerRef}
@@ -888,7 +894,7 @@ function MarkerEditor({ clip, selectedMarkerRef, onAddMarker, onUpdateMarker, on
 
 function Plots({ energySeries, camelotSeries, pxPerSec, seconds, onHover }) {
   const width = Math.ceil(seconds * pxPerSec);
-  const height = 160;
+  const height = 120;
   const energyPath = seriesToPath(energySeries, width, height/2, 0);
   const camelotPath = seriesToPath((camelotSeries||[]).map(v=>v||0), width, height/2, height/2);
 

--- a/dnbSetlist_V3I1.jsx
+++ b/dnbSetlist_V3I1.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
-// DnB Live Set Timeline — v3.1.1 (bugfix)
-// - Fix: unterminated string + missing brace in onPlayheadMouseDown
-// - Fix: CSV export newline ("\n")
-// - Fix: escapeHtml quote map
-// - Keep all v3.1 features
+// DnB Live Set Timeline — v3.2
+// - Markers move with clips
+// - Spacebar toggles play/pause
+// - Display media title and timing
+// - Import YouTube setlists
+// - Clips can move decks & sticky Add Clip button
 
 const BPM = 174;
 const SECS_PER_BEAT = 60 / BPM;
@@ -78,10 +79,26 @@ function buildDemo() {
 }
 
 export default function App() {
-  const MIN_ZOOM = 0.15, MAX_ZOOM = 6;
+  const MIN_ZOOM = 0.02, MAX_ZOOM = 6;
   const [zoom, setZoom] = useState(1);
   const pxPerBeat = BASE_PX_PER_BEAT * zoom;
   const pxPerSec = pxPerBeat / SECS_PER_BEAT;
+
+  // subtype colors (user-manageable)
+  const initialSubtypes = useMemo(()=> ({ ...TRANSITION_COLORS, ...EFFECT_COLORS }), []);
+  const initialSubtypeTypes = useMemo(()=> ({ ...Object.fromEntries(Object.keys(TRANSITION_COLORS).map(k=>[k,'transition'])), ...Object.fromEntries(Object.keys(EFFECT_COLORS).map(k=>[k,'effect'])) }), []);
+  const [subtypes, setSubtypes] = useState(() => {
+    const saved = localStorage.getItem('dnb_subtypes_v1');
+    if (saved) { try { return JSON.parse(saved); } catch{} }
+    return initialSubtypes;
+  });
+  const [subtypeTypes, setSubtypeTypes] = useState(() => {
+    const saved = localStorage.getItem('dnb_subtype_types_v1');
+    if (saved) { try { return JSON.parse(saved); } catch{} }
+    return initialSubtypeTypes;
+  });
+  useEffect(()=> localStorage.setItem('dnb_subtypes_v1', JSON.stringify(subtypes)), [subtypes]);
+  useEffect(()=> localStorage.setItem('dnb_subtype_types_v1', JSON.stringify(subtypeTypes)), [subtypeTypes]);
 
   const [clips, setClips] = useState(() => { const saved = localStorage.getItem('dnb_timeline_v2'); if (saved) { try { return JSON.parse(saved); } catch {} } return buildDemo(); });
   useEffect(()=> localStorage.setItem('dnb_timeline_v2', JSON.stringify(clips)), [clips]);
@@ -90,14 +107,16 @@ export default function App() {
   const selectedClip = clips.find(c=>c.id===selectedClipId) || null;
   const [selectedMarkerRef, setSelectedMarkerRef] = useState(null);
 
-  // subtype colors (user-manageable)
-  const initialSubtypes = useMemo(()=> ({ ...TRANSITION_COLORS, ...EFFECT_COLORS }), []);
-  const initialSubtypeTypes = useMemo(()=> ({ ...Object.fromEntries(Object.keys(TRANSITION_COLORS).map(k=>[k,'transition'])), ...Object.fromEntries(Object.keys(EFFECT_COLORS).map(k=>[k,'effect'])) }), []);
-  const [subtypeTypes] = useState(initialSubtypeTypes);
-  const [subtypes] = useState(initialSubtypes);
-
   // media state
   const [mediaDurationSec, setMediaDurationSec] = useState(0);
+  const [mediaInfo, setMediaInfo] = useState(() => {
+    const saved = localStorage.getItem('dnb_media_info');
+    if (saved) {
+      try { return JSON.parse(saved); } catch {}
+    }
+    return { url: '', title: '' };
+  });
+  useEffect(() => { localStorage.setItem('dnb_media_info', JSON.stringify(mediaInfo)); }, [mediaInfo]);
 
   const lastClipEnd = useMemo(()=> Math.max(0, ...clips.map(c => c.endSec || 0)), [clips]);
   const maxEnd = Math.max(120, mediaDurationSec || 0, lastClipEnd) + DEFAULT_TAIL_PADDING_SEC;
@@ -131,7 +150,22 @@ export default function App() {
     if (noOverlapOnInsert(clip, clips)) { setClips(prev=>[...prev, clip]); setSelectedClipId(clip.id); } else alert('Cannot insert: overlaps an existing clip on this track.');
   }
 
-  function updateClip(id, patch) { setClips(prev=>{ const idx = prev.findIndex(c=>c.id===id); if (idx===-1) return prev; const updated = { ...prev[idx], ...patch }; if (updated.endSec <= updated.startSec) updated.endSec = updated.startSec + 0.001; const others = prev.filter((_,i)=>i!==idx); if (!noOverlap(updated, others)) return prev; const copy = [...prev]; copy[idx]=updated; return copy; }); }
+  function updateClip(id, patch) {
+    setClips(prev=>{
+      const idx = prev.findIndex(c=>c.id===id);
+      if (idx===-1) return prev;
+      const current = prev[idx];
+      const updated = { ...current, ...patch };
+      if (updated.endSec <= updated.startSec) updated.endSec = updated.startSec + 0.001;
+      const others = prev.filter((_,i)=>i!==idx);
+      if (!noOverlap(updated, others)) return prev;
+      if (patch.startSec != null && patch.startSec !== current.startSec) {
+        const delta = patch.startSec - current.startSec;
+        updated.markers = (current.markers||[]).map(m => ({ ...m, startSec: m.startSec + delta, endSec: m.endSec != null ? m.endSec + delta : undefined }));
+      }
+      const copy = [...prev]; copy[idx]=updated; return copy;
+    });
+  }
   function deleteClip(id) { setClips(prev=> prev.filter(c=>c.id!==id)); if (selectedClipId===id) setSelectedClipId(null); if (selectedMarkerRef && selectedMarkerRef.clipId === id) setSelectedMarkerRef(null); }
 
   function addMarker(clipId, marker) { // marker may have startSec/endSec (preferred) or startBeat/endBeat
@@ -139,6 +173,28 @@ export default function App() {
   }
   function updateMarker(clipId, markerId, patch) { setClips(prev=> prev.map(c=> { if (c.id!==clipId) return c; return { ...c, markers: (c.markers||[]).map(m=> m.id===markerId ? normalizeMarker({ ...m, ...patch }, c) : m) }; })); }
   function deleteMarker(clipId, markerId) { setClips(prev=> prev.map(c=> c.id===clipId ? { ...c, markers: (c.markers||[]).filter(m=> m.id!==markerId) } : c)); if (selectedMarkerRef && selectedMarkerRef.clipId===clipId && selectedMarkerRef.markerId===markerId) setSelectedMarkerRef(null); }
+
+  // subtype management
+  function addSubtype(name, type, color) {
+    if (!name) return;
+    setSubtypes(prev => ({ ...prev, [name]: color }));
+    setSubtypeTypes(prev => ({ ...prev, [name]: type }));
+  }
+  function updateSubtype(name, patch) {
+    if (!name) return;
+    if (patch.color != null) setSubtypes(prev => ({ ...prev, [name]: patch.color }));
+    if (patch.type) setSubtypeTypes(prev => ({ ...prev, [name]: patch.type }));
+  }
+  function deleteSubtype(name) {
+    setSubtypes(prev => { const cp={...prev}; delete cp[name]; return cp; });
+    setSubtypeTypes(prev => { const cp={...prev}; delete cp[name]; return cp; });
+  }
+
+  function clearAllClips() {
+    setClips([]);
+    setSelectedClipId(null);
+    setSelectedMarkerRef(null);
+  }
 
   function normalizeMarker(m, clip) {
     const out = { ...m };
@@ -162,10 +218,47 @@ export default function App() {
     const blob = new Blob([csv], { type: 'text/csv' }); const url = URL.createObjectURL(blob); download(url,'timeline.csv');
   }
   function download(url, filename){ const a=document.createElement('a'); a.href=url; a.download=filename; document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url); }
-  function importJSON(file){ const r=new FileReader(); r.onload=()=>{ try{ const data = JSON.parse(String(r.result)); if (data && Array.isArray(data.clips)) { setSubtypes(data.subtypes||initialSubtypes); // preserve if present
-      // setSubtypeTypes not exposed for edit in 3.1.1 but we keep from file if present
-      // eslint-disable-next-line no-unused-expressions
-      data.subtypeTypes; setClips(data.clips); } else if (Array.isArray(data)) { setClips(data); } }catch(e){ alert('Invalid JSON file'); console.error(e); } }; r.readAsText(file); }
+  function importJSON(file){ const r=new FileReader(); r.onload=()=>{ try{ const data = JSON.parse(String(r.result)); if (data && Array.isArray(data.clips)) { setSubtypes(data.subtypes||initialSubtypes); setSubtypeTypes(data.subtypeTypes||initialSubtypeTypes); setClips(data.clips); } else if (Array.isArray(data)) { setClips(data); } }catch(e){ alert('Invalid JSON file'); console.error(e); } }; r.readAsText(file); }
+  function importYTSetlist(file){
+    const r = new FileReader();
+    r.onload = () => {
+      clearAllClips();
+      const text = String(r.result||'');
+      const lines = text.split(/\r?\n/).map(l=>l.trim()).filter(Boolean);
+      const newClips = [];
+      for (const line of lines){
+        const m = line.match(/^(\d+):(\d{2})\s+(.*)$/);
+        if (!m) continue;
+        const startSec = Number(m[1])*60 + Number(m[2]);
+        const name = m[3];
+        newClips.push({ id: uid('clip'), track:0, name, startSec, endSec:startSec+60, baseColor:'#3b82f6', remixType:'None', camelot:'', genre:'DnB', subgenre:'Liquid', energy:5, markers:[] });
+      }
+      newClips.sort((a,b)=> a.startSec - b.startSec);
+      // adjust end times based on next start if not overlapping
+      for (let i=0; i<newClips.length; i++){
+        const next = newClips[i+1];
+        if (next){
+          const diff = next.startSec - newClips[i].startSec;
+          if (diff >= 60) newClips[i].endSec = next.startSec;
+        }
+      }
+      const trackEnds = [];
+      let lastDeck = -1;
+      for (const c of newClips){
+        let t = 0;
+        while(trackEnds[t] && trackEnds[t] > c.startSec) t++;
+        if (t === lastDeck) {
+          t++;
+          while(trackEnds[t] && trackEnds[t] > c.startSec) t++;
+        }
+        c.track = t;
+        trackEnds[t] = c.endSec;
+        lastDeck = t;
+      }
+      setClips(newClips);
+    };
+    r.readAsText(file);
+  }
 
   // YouTube / SoundCloud loader
   function loadYouTubeAPI(cb) {
@@ -184,13 +277,14 @@ export default function App() {
     const el = document.getElementById('player-container'); if (!el) return; el.innerHTML = '';
     playerRef.current = null; playerTypeRef.current = null; playerReadyRef.current = false;
     setMediaDurationSec(0);
-    if (!link) return;
+    if (!link) { setMediaInfo({ url: '', title: '' }); return; }
+    setMediaInfo({ url: link, title: '' });
     if (/youtube.com|youtu.be/.test(link)) {
       playerTypeRef.current = 'youtube';
       loadYouTubeAPI(()=>{
         const id = uid('yt');
         const iframe = document.createElement('div'); iframe.id = id; el.appendChild(iframe);
-        playerRef.current = new window.YT.Player(id, { height: '0', width: '0', videoId: extractYouTubeId(link), playerVars: { start: 0, controls: 1 }, events: { onReady: ()=> { playerReadyRef.current = true; try { const d = playerRef.current.getDuration?.() || 0; if (d) setMediaDurationSec(d); } catch {} }, onStateChange: onYTStateChange } });
+        playerRef.current = new window.YT.Player(id, { height: '0', width: '0', videoId: extractYouTubeId(link), playerVars: { start: 0, controls: 1 }, events: { onReady: ()=> { playerReadyRef.current = true; try { const d = playerRef.current.getDuration?.() || 0; if (d) setMediaDurationSec(d); const t = playerRef.current.getVideoData?.().title; if (t) setMediaInfo(mi => ({ ...mi, title: t })); } catch {} }, onStateChange: onYTStateChange } });
       });
     } else if (/soundcloud.com/.test(link)) {
       playerTypeRef.current = 'soundcloud';
@@ -200,6 +294,7 @@ export default function App() {
         playerRef.current = widget;
         playerReadyRef.current = true;
         try { widget.getDuration?.((ms)=> setMediaDurationSec((ms||0)/1000)); } catch {}
+        try { widget.getCurrentSound?.(sound => { if (sound && sound.title) setMediaInfo(mi => ({ ...mi, title: sound.title })); }); } catch {}
       });
     } else {
       alert('Unsupported link. Use YouTube or SoundCloud URL.');
@@ -210,6 +305,14 @@ export default function App() {
   }
 
   function onYTStateChange(e) { /* no-op for now */ }
+
+  useEffect(() => {
+    if (mediaInfo.url) {
+      const input = document.getElementById('media-url');
+      if (input) input.value = mediaInfo.url;
+      attachPlayer(mediaInfo.url);
+    }
+  }, []);
 
   // playback loop and sync
   useEffect(()=>{
@@ -253,6 +356,14 @@ export default function App() {
     }
   }
 
+  const playPauseRef = useRef(playPauseToggle);
+  playPauseRef.current = playPauseToggle;
+  useEffect(() => {
+    const onKey = (e) => { if (e.code === 'Space') { e.preventDefault(); playPauseRef.current(); } };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
   function seekTo(sec) {
     setPlayheadSec(sec);
     if (playerReadyRef.current && playerRef.current) {
@@ -269,7 +380,7 @@ export default function App() {
   return (
     <div className="min-h-screen p-4 bg-slate-50 text-slate-900" ref={containerRef}>
       <header className="flex items-center justify-between mb-3">
-        <h1 className="text-2xl font-bold">DnB Live Set Timeline (v3.1.1)</h1>
+        <h1 className="text-2xl font-bold">DnB Live Set Timeline (v3.2)</h1>
         <div className="flex gap-2 items-center">
           <input placeholder="YouTube or SoundCloud URL" id="media-url" className="px-2 py-1 border rounded" onBlur={(e)=> attachPlayer(e.target.value)} />
           <div id="player-container" style={{ width:200 }} />
@@ -278,7 +389,15 @@ export default function App() {
           <button onClick={exportJSON} className="px-3 py-1 rounded bg-slate-900 text-white">Export JSON</button>
           <button onClick={exportCSV} className="px-3 py-1 rounded bg-slate-900 text-white">Export CSV</button>
           <label className="px-3 py-1 bg-white border rounded cursor-pointer">Import JSON<input type="file" accept="application/json" className="hidden" onChange={e=> { const f = e.target.files?.[0]; if (f) importJSON(f); }} /></label>
+          <label className="px-3 py-1 bg-white border rounded cursor-pointer">Import Setlist<input type="file" accept="text/plain" className="hidden" onChange={e=> { const f=e.target.files?.[0]; if(f) importYTSetlist(f); }} /></label>
+          <button onClick={clearAllClips} className="px-3 py-1 rounded bg-white border">Clear Clips</button>
         </div>
+        {mediaInfo.title && (
+          <div className="text-xs text-right ml-4">
+            <div className="font-semibold">{mediaInfo.title}</div>
+            <div>{fmtTime(playheadSec)} / {fmtTime(Math.max(mediaDurationSec - playheadSec,0))} left</div>
+          </div>
+        )}
       </header>
 
       <div className="bg-white rounded p-3 shadow overflow-auto">
@@ -330,7 +449,7 @@ export default function App() {
       </div>
 
       <div className="mb-3 flex items-center gap-2">
-        <Legend subtypes={subtypes} subtypeTypes={subtypeTypes} />
+        <Legend subtypes={subtypes} subtypeTypes={subtypeTypes} onAddSubtype={addSubtype} onUpdateSubtype={updateSubtype} onDeleteSubtype={deleteSubtype} />
       </div>
 
       <Inspector
@@ -369,12 +488,15 @@ function BigTimelineHeader({ widthPx, pxPerBeat, pxPerSec, clips, subtypes, onSe
 
   function onClick(e){ const rect = e.currentTarget.getBoundingClientRect(); const x = e.clientX - rect.left; const sec = pxToSec(x, pxPerBeat); onSeek && onSeek(clamp(sec,0,totalSec)); }
 
-  // build mm:ss second grid (labels every 5s)
+  // build second grid with adaptive spacing when zoomed out
   const gridEls = [];
-  const labelStep = 5; // seconds
-  for (let s=0; s<= totalSec; s+=1) {
+  const minLabelPx = 60; // minimum pixels between time labels
+  let labelStep = 5;
+  while (secToPx(labelStep, pxPerBeat) < minLabelPx) labelStep *= 2;
+  const gridStep = Math.max(1, labelStep / 5);
+  for (let s = 0; s <= totalSec; s += gridStep) {
     const x = Math.round(secToPx(s, pxPerBeat));
-    const isLabel = s % labelStep === 0;
+    const isLabel = Math.abs(s % labelStep) < 1e-6;
     gridEls.push(
       <div key={`g-${s}`} style={{ position:'absolute', left: x, top: 0, bottom: 0, width: 1, background: isLabel ? 'rgba(0,0,0,0.18)' : 'rgba(0,0,0,0.06)' }} />
     );
@@ -412,8 +534,8 @@ function BigTimelineHeader({ widthPx, pxPerBeat, pxPerSec, clips, subtypes, onSe
   );
 }
 
-function Legend({ subtypes, subtypeTypes }) {
-  const types = ['transition', 'effect'];
+function Legend({ subtypes, subtypeTypes, onAddSubtype, onUpdateSubtype, onDeleteSubtype }) {
+  const [manage, setManage] = useState(false);
   return (
     <div className="flex gap-6 items-start w-full justify-between">
       <div className="text-sm">
@@ -424,27 +546,28 @@ function Legend({ subtypes, subtypeTypes }) {
       </div>
 
       <div className="text-sm flex-1">
-        <div className="font-semibold">Markers (Subtypes)</div>
-        <div className="mt-1">
-          {types.map(type => (
-            <div key={type} className="mb-2">
-              <div className="text-xs font-medium mb-1">{type[0].toUpperCase() + type.slice(1)}</div>
-              <div className="flex gap-3 flex-wrap items-center">
-                {Object.keys(subtypes).filter(name => (subtypeTypes[name] || 'transition') === type).map(name => (
-                  <div key={name} className="flex items-center gap-2 border px-2 py-1 rounded">
-                    {/* shape changes: triangle for effects, square for transitions */}
-                    {type === 'effect' ? (
-                      <div style={{ width: 0, height: 0, borderLeft: '7px solid transparent', borderRight: '7px solid transparent', borderBottom: `12px solid ${subtypes[name]}` }} />
-                    ) : (
-                      <div style={{width:14,height:14,background: subtypes[name],borderRadius:3}} />
-                    )}
-                    <div className="text-xs">{name}</div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
+        <div className="flex items-center justify-between">
+          <div className="font-semibold">Markers (Subtypes)</div>
+          <button className="text-xs underline" onClick={()=> setManage(m=>!m)}>{manage? 'Close':'Manage'}</button>
         </div>
+        <div className="mt-1 flex gap-3 flex-wrap items-center">
+          {Object.keys(subtypes).map(name => {
+            const type = subtypeTypes[name] || 'transition';
+            return (
+              <div key={name} className="flex items-center gap-2 border px-2 py-1 rounded">
+                {type === 'effect' ? (
+                  <div style={{ width: 0, height: 0, borderLeft: '7px solid transparent', borderRight: '7px solid transparent', borderBottom: `12px solid ${subtypes[name]}` }} />
+                ) : (
+                  <div style={{width:14,height:14,background: subtypes[name],borderRadius:3}} />
+                )}
+                <div className="text-xs">{name}</div>
+              </div>
+            );
+          })}
+        </div>
+        {manage && (
+          <SubtypeManager subtypes={subtypes} subtypeTypes={subtypeTypes} onAdd={onAddSubtype} onUpdate={onUpdateSubtype} onDelete={onDeleteSubtype} />
+        )}
       </div>
 
       <div className="text-sm">
@@ -457,26 +580,62 @@ function Legend({ subtypes, subtypeTypes }) {
   );
 }
 
-function TrackRow({ children, trackIndex, widthPx, pxPerBeat, onAdd }) {
+function SubtypeManager({ subtypes, subtypeTypes, onAdd, onUpdate, onDelete }) {
+  const [newName, setNewName] = useState('');
+  const [newType, setNewType] = useState('transition');
+  const [newColor, setNewColor] = useState('#000000');
   return (
-    <div className="mb-3">
-      <div className="flex items-center gap-2 mb-1">
-        <div className="px-2 py-0.5 bg-slate-800 text-white rounded text-xs">Deck {trackIndex+1}</div>
-      </div>
-      <div id={`track-${trackIndex}`} className="relative h-40 rounded-xl border overflow-hidden" style={{ width: widthPx }}>
-        <GridBackground pxPerBeat={pxPerBeat} />
-        {/* Add Clip button pinned to right side */}
-        <button className="px-2 py-1 rounded bg-white border absolute top-2 right-2" onClick={onAdd}>+ Add Clip</button>
-        {children}
+    <div className="mt-2 border-t pt-2">
+      {Object.keys(subtypes).map(name => (
+        <div key={name} className="flex items-center gap-2 mb-1 text-xs">
+          <div className="w-24 truncate">{name}</div>
+          <select className="px-1 py-0.5 border rounded" value={subtypeTypes[name]||'transition'} onChange={(e)=> onUpdate(name,{ type:e.target.value })}>
+            <option value="transition">Transition</option>
+            <option value="effect">Effect</option>
+          </select>
+          <input type="color" className="h-6 w-10" value={subtypes[name]} onChange={(e)=> onUpdate(name,{ color:e.target.value })} />
+          <button className="px-1.5 py-0.5 bg-rose-600 text-white rounded" onClick={()=> onDelete(name)}>x</button>
+        </div>
+      ))}
+      <div className="flex items-center gap-2 mt-2 text-xs">
+        <input className="flex-1 px-1 py-0.5 border rounded" placeholder="Name" value={newName} onChange={(e)=> setNewName(e.target.value)} />
+        <select className="px-1 py-0.5 border rounded" value={newType} onChange={(e)=> setNewType(e.target.value)}>
+          <option value="transition">Transition</option>
+          <option value="effect">Effect</option>
+        </select>
+        <input type="color" className="h-6 w-10" value={newColor} onChange={(e)=> setNewColor(e.target.value)} />
+        <button className="px-2 py-0.5 bg-slate-900 text-white rounded" onClick={()=> { if (!newName.trim()) return; onAdd(newName.trim(), newType, newColor); setNewName(''); }}>Add</button>
       </div>
     </div>
   );
 }
 
+function TrackRow({ children, trackIndex, widthPx, pxPerBeat, onAdd }) {
+  return (
+    <div className="mb-3 flex items-start relative">
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <div className="px-2 py-0.5 bg-slate-800 text-white rounded text-xs">Deck {trackIndex+1}</div>
+        </div>
+        <div id={`track-${trackIndex}`} className="relative h-28 rounded-xl border overflow-hidden" style={{ width: widthPx }}>
+          <GridBackground pxPerBeat={pxPerBeat} />
+          {children}
+        </div>
+      </div>
+      <button className="px-2 py-1 rounded bg-white border sticky top-2 right-2" onClick={onAdd}>+ Add Clip</button>
+    </div>
+  );
+}
+
 function GridBackground({ pxPerBeat }) {
-  const step = Math.max(8, Math.round(pxPerBeat));
-  const phrase = Math.round(pxPerBeat * BEATS_PER_PHRASE);
-  const style = { backgroundImage: `repeating-linear-gradient(to right, rgba(0,0,0,0.04) 0, rgba(0,0,0,0.04) 1px, transparent 1px, transparent ${step}px), repeating-linear-gradient(to right, transparent 0, transparent ${phrase - 6}px, rgba(0,0,0,0.12) ${phrase - 6}px, rgba(0,0,0,0.12) ${phrase}px)` };
+  let beatStep = 1;
+  const minPx = 20;
+  while (beatStep * pxPerBeat < minPx) beatStep *= 2;
+  const step = pxPerBeat * beatStep;
+  const phrase = step * BEATS_PER_PHRASE;
+  const style = {
+    backgroundImage: `repeating-linear-gradient(to right, rgba(0,0,0,0.04) 0, rgba(0,0,0,0.04) 1px, transparent 1px, transparent ${step}px), repeating-linear-gradient(to right, transparent 0, transparent ${phrase - 2}px, rgba(0,0,0,0.12) ${phrase - 2}px, rgba(0,0,0,0.12) ${phrase}px)`
+  };
   return <div className="absolute inset-0" style={style} />;
 }
 
@@ -502,7 +661,7 @@ function ClipView({ clip, pxPerBeat, pxPerSec, selected, onSelect, onUpdate, onA
   function showMarkerHover(e, m) { const typ = m.type === 'transition' ? 'Transition' : 'Effect'; const detailsHtml = m.details ? ('<div style="max-width:260px;white-space:normal">' + escapeHtml(m.details) + '</div>') : ''; const sr = (m.startSec ?? clip.startSec) - clip.startSec; const er = m.endSec != null ? (m.endSec - clip.startSec) : null; const html = '<div><b>' + typ + (m.label ? ': ' + escapeHtml(m.label) : '') + '</b></div>' + detailsHtml + `<div>Start: ${fmtSec2(sr)}s (${fmtTime(m.startSec ?? clip.startSec)})` + (er != null ? `, End: ${fmtSec2(er)}s (${fmtTime(m.endSec)})` : '') + '</div>'; onHover({ x: e.clientX, y: e.clientY, html }); }
 
   return (
-    <div className={"absolute top-6 rounded-xl border shadow-inner" + (selected ? " ring-2 ring-sky-500" : "")} style={{ left, width, background: bg, cursor: 'grab' }} onMouseDown={startDrag} onMouseEnter={showClipHover} onMouseLeave={() => onClearHover()} onClick={(e) => { e.stopPropagation(); onSelect(); }}>
+    <div className={"absolute rounded-xl border shadow-inner" + (selected ? " ring-2 ring-sky-500" : "")} style={{ left, width, background: bg, cursor: 'grab', top: '10%', height: '80%' }} onMouseDown={startDrag} onMouseEnter={showClipHover} onMouseLeave={() => onClearHover()} onClick={(e) => { e.stopPropagation(); onSelect(); }}>
       <div className="absolute top-0 left-0 right-0 h-3 bg-black/10 hover:bg-black/20 cursor-crosshair" onClick={insertMarkerAtClick} title="Click to add a marker here" />
 
       <div className="px-3 py-2 text-white" style={{ color: '#fff' }}>
@@ -554,14 +713,15 @@ function Inspector({ clip, selectedMarkerRef, onChange, onDelete, onAddMarker, o
 
   if (!clip) return null;
 
-  function updateField(field, value) { setDraft(d=> ({ ...d, [field]: value })); if (selectedMarkerRef) { const patch = { [field]: value }; if (field === 'startSec' or field === 'endSec') { patch[field] = value === '' || value == null ? undefined : Number(value); } onUpdateMarker(selectedMarkerRef.clipId, selectedMarkerRef.markerId, patch); } }
+  function updateField(field, value) { setDraft(d=> ({ ...d, [field]: value })); if (selectedMarkerRef) { const patch = { [field]: value }; if (field === 'startSec' || field === 'endSec') { patch[field] = value === '' || value == null ? undefined : Number(value); } onUpdateMarker(selectedMarkerRef.clipId, selectedMarkerRef.markerId, patch); } }
 
   return (
-    <div className="mt-4 p-4 bg-white rounded shadow grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="mt-4 p-4 bg-white rounded shadow grid grid-cols-2 gap-6">
       <div>
         <div className="text-lg font-semibold mb-2">Clip Inspector</div>
         <div className="grid grid-cols-2 gap-2 text-sm">
           <label className="flex items-center gap-2 col-span-2"><span className="w-28">Name</span><input className="flex-1 px-2 py-1 border rounded" value={clip.name} onChange={(e)=> onChange({ name: e.target.value })} /></label>
+          <label className="flex items-center gap-2"><span className="w-28">Deck</span><select className="flex-1 px-2 py-1 border rounded" value={clip.track} onChange={(e)=> onChange({ track: Number(e.target.value) })}>{Array.from({length:4}).map((_,i)=><option key={i} value={i}>Deck {i+1}</option>)}</select></label>
           <label className="flex items-center gap-2"><span className="w-28">Start (s)</span><input type="number" className="flex-1 px-2 py-1 border rounded" value={fmtSec2(clip.startSec)} step={0.01} onChange={(e)=> onChange({ startSec: Number(e.target.value) || 0 })} /></label>
           <label className="flex items-center gap-2"><span className="w-28">End (s)</span><input type="number" className="flex-1 px-2 py-1 border rounded" value={fmtSec2(clip.endSec)} step={0.01} onChange={(e)=> onChange({ endSec: Number(e.target.value) || 0 })} /></label>
           <div className="col-span-2 text-xs text-slate-600">Duration: {fmtTime(clip.endSec - clip.startSec)} ({fmtSec2((clip.endSec-clip.startSec)/SECS_PER_BEAT)} beats)</div>

--- a/dnbSetlist_V3I1.jsx
+++ b/dnbSetlist_V3I1.jsx
@@ -148,27 +148,6 @@ export default function App() {
     const el = containerRef.current; if (!el) return; const onWheel = (e) => { if (e.ctrlKey) { e.preventDefault(); const factor = e.deltaY < 0 ? 1.12 : 1 / 1.12; setZoom(z=>clamp(z*factor, MIN_ZOOM, MAX_ZOOM)); } }; el.addEventListener('wheel', onWheel, { passive:false }); return ()=> el.removeEventListener('wheel', onWheel);
   }, []);
 
-  const overlapSegments = useMemo(()=> {
-    const segs = [];
-    for (let i=0;i<clips.length;i++){
-      for (let j=i+1;j<clips.length;j++){
-        const a = clips[i], b = clips[j];
-        if (a.track === b.track) continue;
-        const start = Math.max(a.startSec, b.startSec);
-        const end = Math.min(a.endSec, b.endSec);
-        if (start < end) {
-          segs.push({
-            startSec: start,
-            endSec: end,
-            tracks: [a.track, b.track],
-            colorA: subtypes[a.subgenre] || a.baseColor,
-            colorB: subtypes[b.subgenre] || b.baseColor,
-          });
-        }
-      }
-    }
-    return segs;
-  }, [clips, subtypes]);
 
   // migrate any legacy marker beat fields into seconds relative to clip
   useEffect(()=>{
@@ -452,16 +431,6 @@ export default function App() {
             {/* Playhead line */}
             <div onMouseDown={(e)=> onPlayheadMouseDown(e, pxPerBeat, maxEnd, setPlayheadSec)} title={`Playhead: ${fmtTime(playheadSec)} (${fmtSec2(playheadSec)}s)`} style={{ position:'absolute', left: secToPx(playheadSec, pxPerBeat), top:0, bottom:0, width:2, background:'red', zIndex:120 }} />
 
-            {overlapSegments.map((seg,i)=> {
-              const left = secToPx(seg.startSec, pxPerBeat);
-              const width = Math.max(2, secToPx(seg.endSec - seg.startSec, pxPerBeat));
-              const top = Math.min(...seg.tracks)*(TRACK_HEIGHT_PX+ROW_GAP_PX)+TRACK_HEIGHT_PX;
-              const bottom = Math.max(...seg.tracks)*(TRACK_HEIGHT_PX+ROW_GAP_PX);
-              const height = bottom - top;
-              const bg = `linear-gradient(to bottom, ${seg.colorA}, ${seg.colorB})`;
-              return <div key={i} style={{position:'absolute', left, top, width, height, background:bg, opacity:0.4, pointerEvents:'none'}} />;
-            })}
-
             {Array.from({ length: 4 }).map((_, t) => (
               <TrackRow key={t} trackIndex={t} pxPerBeat={pxPerBeat} widthPx={timelineWidthPx} onAdd={() => addClip(t)}>
                 {clips.filter(c => c.track === t).sort((a,b)=>a.startSec-b.startSec).map(clip => (
@@ -626,34 +595,73 @@ function Legend({ subtypes, subtypeTypes, onAddSubtype, onUpdateSubtype, onDelet
 
 
 function SubtypeManager({ subtypes, subtypeTypes, onAdd, onUpdate, onDelete }) {
-  const [newName, setNewName] = useState('');
-  const [newType, setNewType] = useState('transition');
-  const [newColor, setNewColor] = useState('#000000');
+  const clipNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'clip');
+  const markerNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'transition' || subtypeTypes[k] === 'effect');
+  const remixNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'remix');
+
+  const [newClip, setNewClip] = useState({ name: '', color: '#000000' });
+  const [newMarker, setNewMarker] = useState({ name: '', type: 'transition', color: '#000000' });
+  const [newRemix, setNewRemix] = useState({ name: '', color: '#000000' });
+
   return (
-    <div className="mt-2 border-t pt-2">
-      {Object.keys(subtypes).map(name => (
-        <div key={name} className="flex items-center gap-2 mb-1 text-xs">
-          <div className="w-24 truncate">{name}</div>
-          <select className="px-1 py-0.5 border rounded" value={subtypeTypes[name]||'transition'} onChange={(e)=> onUpdate(name,{ type:e.target.value })}>
+    <div className="mt-2 border-t pt-2 grid grid-cols-3 gap-4 text-xs">
+      {/* Clip subgenres */}
+      <div>
+        <div className="font-semibold mb-1">Clips</div>
+        {clipNames.map(name => (
+          <div key={name} className="flex items-center gap-2 mb-1">
+            <div className="w-24 truncate">{name}</div>
+            <input type="color" className="h-6 w-10" value={subtypes[name]} onChange={e=> onUpdate(name,{ color:e.target.value })} />
+            <button className="px-1.5 py-0.5 bg-rose-600 text-white rounded" onClick={()=> onDelete(name)}>x</button>
+          </div>
+        ))}
+        <div className="flex items-center gap-2 mt-2">
+          <input className="flex-1 px-1 py-0.5 border rounded" placeholder="Name" value={newClip.name} onChange={e=> setNewClip({ ...newClip, name:e.target.value })} />
+          <input type="color" className="h-6 w-10" value={newClip.color} onChange={e=> setNewClip({ ...newClip, color:e.target.value })} />
+          <button className="px-2 py-0.5 bg-slate-900 text-white rounded" onClick={()=> { if(!newClip.name.trim()) return; onAdd(newClip.name.trim(),'clip',newClip.color); setNewClip({ name:'', color:'#000000' }); }}>Add</button>
+        </div>
+      </div>
+
+      {/* Marker subtypes */}
+      <div>
+        <div className="font-semibold mb-1">Markers</div>
+        {markerNames.map(name => (
+          <div key={name} className="flex items-center gap-2 mb-1">
+            <div className="w-24 truncate">{name}</div>
+            <select className="px-1 py-0.5 border rounded" value={subtypeTypes[name]||'transition'} onChange={e=> onUpdate(name,{ type:e.target.value })}>
+              <option value="transition">Transition</option>
+              <option value="effect">Effect</option>
+            </select>
+            <input type="color" className="h-6 w-10" value={subtypes[name]} onChange={e=> onUpdate(name,{ color:e.target.value })} />
+            <button className="px-1.5 py-0.5 bg-rose-600 text-white rounded" onClick={()=> onDelete(name)}>x</button>
+          </div>
+        ))}
+        <div className="flex items-center gap-2 mt-2">
+          <input className="flex-1 px-1 py-0.5 border rounded" placeholder="Name" value={newMarker.name} onChange={e=> setNewMarker({ ...newMarker, name:e.target.value })} />
+          <select className="px-1 py-0.5 border rounded" value={newMarker.type} onChange={e=> setNewMarker({ ...newMarker, type:e.target.value })}>
             <option value="transition">Transition</option>
             <option value="effect">Effect</option>
-            <option value="clip">Clip</option>
-            <option value="remix">Remix</option>
           </select>
-          <input type="color" className="h-6 w-10" value={subtypes[name]} onChange={(e)=> onUpdate(name,{ color:e.target.value })} />
-          <button className="px-1.5 py-0.5 bg-rose-600 text-white rounded" onClick={()=> onDelete(name)}>x</button>
+          <input type="color" className="h-6 w-10" value={newMarker.color} onChange={e=> setNewMarker({ ...newMarker, color:e.target.value })} />
+          <button className="px-2 py-0.5 bg-slate-900 text-white rounded" onClick={()=> { if(!newMarker.name.trim()) return; onAdd(newMarker.name.trim(), newMarker.type, newMarker.color); setNewMarker({ name:'', type:'transition', color:'#000000' }); }}>Add</button>
         </div>
-      ))}
-      <div className="flex items-center gap-2 mt-2 text-xs">
-        <input className="flex-1 px-1 py-0.5 border rounded" placeholder="Name" value={newName} onChange={(e)=> setNewName(e.target.value)} />
-        <select className="px-1 py-0.5 border rounded" value={newType} onChange={(e)=> setNewType(e.target.value)}>
-          <option value="transition">Transition</option>
-          <option value="effect">Effect</option>
-          <option value="clip">Clip</option>
-          <option value="remix">Remix</option>
-        </select>
-        <input type="color" className="h-6 w-10" value={newColor} onChange={(e)=> setNewColor(e.target.value)} />
-        <button className="px-2 py-0.5 bg-slate-900 text-white rounded" onClick={()=> { if (!newName.trim()) return; onAdd(newName.trim(), newType, newColor); setNewName(''); }}>Add</button>
+      </div>
+
+      {/* Remix types */}
+      <div>
+        <div className="font-semibold mb-1">Remix</div>
+        {remixNames.map(name => (
+          <div key={name} className="flex items-center gap-2 mb-1">
+            <div className="w-24 truncate">{name}</div>
+            <input type="color" className="h-6 w-10" value={subtypes[name]} onChange={e=> onUpdate(name,{ color:e.target.value })} />
+            <button className="px-1.5 py-0.5 bg-rose-600 text-white rounded" onClick={()=> onDelete(name)}>x</button>
+          </div>
+        ))}
+        <div className="flex items-center gap-2 mt-2">
+          <input className="flex-1 px-1 py-0.5 border rounded" placeholder="Name" value={newRemix.name} onChange={e=> setNewRemix({ ...newRemix, name:e.target.value })} />
+          <input type="color" className="h-6 w-10" value={newRemix.color} onChange={e=> setNewRemix({ ...newRemix, color:e.target.value })} />
+          <button className="px-2 py-0.5 bg-slate-900 text-white rounded" onClick={()=> { if(!newRemix.name.trim()) return; onAdd(newRemix.name.trim(),'remix',newRemix.color); setNewRemix({ name:'', color:'#000000' }); }}>Add</button>
+        </div>
       </div>
     </div>
   );

--- a/dnbSetlist_V3I1.jsx
+++ b/dnbSetlist_V3I1.jsx
@@ -83,10 +83,22 @@ export default function App() {
   const [zoom, setZoom] = useState(1);
   const pxPerBeat = BASE_PX_PER_BEAT * zoom;
   const pxPerSec = pxPerBeat / SECS_PER_BEAT;
+  const TRACK_HEIGHT_PX = 112;
+  const ROW_GAP_PX = 12;
 
   // subtype colors (user-manageable)
-  const initialSubtypes = useMemo(()=> ({ ...TRANSITION_COLORS, ...EFFECT_COLORS }), []);
-  const initialSubtypeTypes = useMemo(()=> ({ ...Object.fromEntries(Object.keys(TRANSITION_COLORS).map(k=>[k,'transition'])), ...Object.fromEntries(Object.keys(EFFECT_COLORS).map(k=>[k,'effect'])) }), []);
+  const initialSubtypes = useMemo(()=> ({
+    ...TRANSITION_COLORS,
+    ...EFFECT_COLORS,
+    ...SUBGENRE_COLORS,
+    ...REMIX_COLORS,
+  }), []);
+  const initialSubtypeTypes = useMemo(()=> ({
+    ...Object.fromEntries(Object.keys(TRANSITION_COLORS).map(k=>[k,'transition'])),
+    ...Object.fromEntries(Object.keys(EFFECT_COLORS).map(k=>[k,'effect'])),
+    ...Object.fromEntries(Object.keys(SUBGENRE_COLORS).map(k=>[k,'clip'])),
+    ...Object.fromEntries(Object.keys(REMIX_COLORS).map(k=>[k,'remix'])),
+  }), []);
   const [subtypes, setSubtypes] = useState(() => {
     const saved = localStorage.getItem('dnb_subtypes_v1');
     if (saved) { try { return JSON.parse(saved); } catch{} }
@@ -136,6 +148,28 @@ export default function App() {
     const el = containerRef.current; if (!el) return; const onWheel = (e) => { if (e.ctrlKey) { e.preventDefault(); const factor = e.deltaY < 0 ? 1.12 : 1 / 1.12; setZoom(z=>clamp(z*factor, MIN_ZOOM, MAX_ZOOM)); } }; el.addEventListener('wheel', onWheel, { passive:false }); return ()=> el.removeEventListener('wheel', onWheel);
   }, []);
 
+  const overlapSegments = useMemo(()=> {
+    const segs = [];
+    for (let i=0;i<clips.length;i++){
+      for (let j=i+1;j<clips.length;j++){
+        const a = clips[i], b = clips[j];
+        if (a.track === b.track) continue;
+        const start = Math.max(a.startSec, b.startSec);
+        const end = Math.min(a.endSec, b.endSec);
+        if (start < end) {
+          segs.push({
+            startSec: start,
+            endSec: end,
+            tracks: [a.track, b.track],
+            colorA: subtypes[a.subgenre] || a.baseColor,
+            colorB: subtypes[b.subgenre] || b.baseColor,
+          });
+        }
+      }
+    }
+    return segs;
+  }, [clips, subtypes]);
+
   // migrate any legacy marker beat fields into seconds relative to clip
   useEffect(()=>{
     setClips(prev => prev.map(c => ({ ...c, markers: (c.markers||[]).map(m => {
@@ -146,7 +180,7 @@ export default function App() {
   }, []);
 
   function addClip(track) {
-    const trackClips = clips.filter(c=>c.track===track); const lastEndT = trackClips.reduce((acc,c)=>Math.max(acc, c.endSec), 0); const gap = 1; const startSec = lastEndT>0? lastEndT+gap : 0; const endSec = startSec + SECS_PER_BEAT * BEATS_PER_PHRASE; const clip = { id: uid('clip'), track, name: 'New Clip', startSec, endSec, baseColor: '#3b82f6', remixType: 'None', camelot: '8A', genre: 'DnB', subgenre: 'Liquid', energy: 6, markers: [] };
+    const trackClips = clips.filter(c=>c.track===track); const lastEndT = trackClips.reduce((acc,c)=>Math.max(acc, c.endSec), 0); const gap = 1; const startSec = lastEndT>0? lastEndT+gap : 0; const endSec = startSec + SECS_PER_BEAT * BEATS_PER_PHRASE; const clip = { id: uid('clip'), track, name: 'New Clip', startSec, endSec, baseColor: subtypes['Liquid'] || '#3b82f6', remixType: 'None', camelot: '8A', genre: 'DnB', subgenre: 'Liquid', energy: 6, markers: [] };
     if (noOverlapOnInsert(clip, clips)) { setClips(prev=>[...prev, clip]); setSelectedClipId(clip.id); } else alert('Cannot insert: overlaps an existing clip on this track.');
   }
 
@@ -231,7 +265,7 @@ export default function App() {
         if (!m) continue;
         const startSec = Number(m[1])*60 + Number(m[2]);
         const name = m[3];
-        newClips.push({ id: uid('clip'), track:0, name, startSec, endSec:startSec+60, baseColor:'#3b82f6', remixType:'None', camelot:'', genre:'DnB', subgenre:'Liquid', energy:5, markers:[] });
+        newClips.push({ id: uid('clip'), track:0, name, startSec, endSec:startSec+60, baseColor: subtypes['Liquid'] || '#3b82f6', remixType:'None', camelot:'', genre:'DnB', subgenre:'Liquid', energy:5, markers:[] });
       }
       newClips.sort((a,b)=> a.startSec - b.startSec);
       // adjust end times based on next start if not overlapping
@@ -418,6 +452,16 @@ export default function App() {
             {/* Playhead line */}
             <div onMouseDown={(e)=> onPlayheadMouseDown(e, pxPerBeat, maxEnd, setPlayheadSec)} title={`Playhead: ${fmtTime(playheadSec)} (${fmtSec2(playheadSec)}s)`} style={{ position:'absolute', left: secToPx(playheadSec, pxPerBeat), top:0, bottom:0, width:2, background:'red', zIndex:120 }} />
 
+            {overlapSegments.map((seg,i)=> {
+              const left = secToPx(seg.startSec, pxPerBeat);
+              const width = Math.max(2, secToPx(seg.endSec - seg.startSec, pxPerBeat));
+              const top = Math.min(...seg.tracks)*(TRACK_HEIGHT_PX+ROW_GAP_PX)+TRACK_HEIGHT_PX;
+              const bottom = Math.max(...seg.tracks)*(TRACK_HEIGHT_PX+ROW_GAP_PX);
+              const height = bottom - top;
+              const bg = `linear-gradient(to bottom, ${seg.colorA}, ${seg.colorB})`;
+              return <div key={i} style={{position:'absolute', left, top, width, height, background:bg, opacity:0.4, pointerEvents:'none'}} />;
+            })}
+
             {Array.from({ length: 4 }).map((_, t) => (
               <TrackRow key={t} trackIndex={t} pxPerBeat={pxPerBeat} widthPx={timelineWidthPx} onAdd={() => addClip(t)}>
                 {clips.filter(c => c.track === t).sort((a,b)=>a.startSec-b.startSec).map(clip => (
@@ -534,25 +578,26 @@ function BigTimelineHeader({ widthPx, pxPerBeat, pxPerSec, clips, subtypes, onSe
   );
 }
 
+
 function Legend({ subtypes, subtypeTypes, onAddSubtype, onUpdateSubtype, onDeleteSubtype }) {
   const [manage, setManage] = useState(false);
+  const clipNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'clip');
+  const markerNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'transition' || subtypeTypes[k] === 'effect');
+  const remixNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'remix');
   return (
-    <div className="flex gap-6 items-start w-full justify-between">
-      <div className="text-sm">
-        <div className="font-semibold">Clips (Subgenre)</div>
-        <div className="flex gap-2 mt-1">{Object.entries(SUBGENRE_COLORS).map(([k,v]) => (
-          <div key={k} className="flex items-center gap-1"><div style={{width:12,height:12,background:v,borderRadius:3}}/><div className="text-xs">{k}</div></div>
-        ))}</div>
-      </div>
-
-      <div className="text-sm flex-1">
-        <div className="flex items-center justify-between">
-          <div className="font-semibold">Markers (Subtypes)</div>
-          <button className="text-xs underline" onClick={()=> setManage(m=>!m)}>{manage? 'Close':'Manage'}</button>
+    <div className="relative w-full border rounded p-3">
+      <button className="absolute top-2 right-2 text-xs underline" onClick={()=> setManage(m=>!m)}>{manage? 'Close':'Manage'}</button>
+      <div className="text-sm flex flex-col gap-2">
+        <div>
+          <div className="font-semibold">Clips (Subgenre)</div>
+          <div className="flex gap-2 mt-1 flex-wrap">{clipNames.map(name => (
+            <div key={name} className="flex items-center gap-1"><div style={{width:12,height:12,background: subtypes[name],borderRadius:3}}/><div className="text-xs">{name}</div></div>
+          ))}</div>
         </div>
-        <div className="mt-1 flex gap-3 flex-wrap items-center">
-          {Object.keys(subtypes).map(name => {
-            const type = subtypeTypes[name] || 'transition';
+        <div className="border-t pt-2">
+          <div className="font-semibold">Markers</div>
+          <div className="mt-1 flex gap-3 flex-wrap items-center">{markerNames.map(name => {
+            const type = subtypeTypes[name];
             return (
               <div key={name} className="flex items-center gap-2 border px-2 py-1 rounded">
                 {type === 'effect' ? (
@@ -563,22 +608,22 @@ function Legend({ subtypes, subtypeTypes, onAddSubtype, onUpdateSubtype, onDelet
                 <div className="text-xs">{name}</div>
               </div>
             );
-          })}
+          })}</div>
         </div>
-        {manage && (
-          <SubtypeManager subtypes={subtypes} subtypeTypes={subtypeTypes} onAdd={onAddSubtype} onUpdate={onUpdateSubtype} onDelete={onDeleteSubtype} />
-        )}
+        <div className="border-t pt-2">
+          <div className="font-semibold">Remix (Striped)</div>
+          <div className="flex gap-2 mt-1 flex-wrap">{remixNames.map(name => (
+            <div key={name} className="flex items-center gap-1"><div style={{width:12,height:12,background: subtypes[name] ? `repeating-linear-gradient(45deg, ${subtypes[name]}, ${subtypes[name]} 6px, #fff 6px, #fff 12px)` : '#fff', border:'1px solid #ddd', borderRadius:3}}/><div className="text-xs">{name}</div></div>
+          ))}</div>
+        </div>
       </div>
-
-      <div className="text-sm">
-        <div className="font-semibold">Remix (Striped)</div>
-        <div className="flex gap-2 mt-1">{Object.entries(REMIX_COLORS).map(([k,v]) => (
-          <div key={k} className="flex items-center gap-1"><div style={{width:12,height:12,background: v ? `repeating-linear-gradient(45deg, ${v}, ${v} 6px, #fff 6px, #fff 12px)` : '#fff', border:'1px solid #ddd', borderRadius:3}}/><div className="text-xs">{k}</div></div>
-        ))}</div>
-      </div>
+      {manage && (
+        <SubtypeManager subtypes={subtypes} subtypeTypes={subtypeTypes} onAdd={onAddSubtype} onUpdate={onUpdateSubtype} onDelete={onDeleteSubtype} />
+      )}
     </div>
   );
 }
+
 
 function SubtypeManager({ subtypes, subtypeTypes, onAdd, onUpdate, onDelete }) {
   const [newName, setNewName] = useState('');
@@ -592,6 +637,8 @@ function SubtypeManager({ subtypes, subtypeTypes, onAdd, onUpdate, onDelete }) {
           <select className="px-1 py-0.5 border rounded" value={subtypeTypes[name]||'transition'} onChange={(e)=> onUpdate(name,{ type:e.target.value })}>
             <option value="transition">Transition</option>
             <option value="effect">Effect</option>
+            <option value="clip">Clip</option>
+            <option value="remix">Remix</option>
           </select>
           <input type="color" className="h-6 w-10" value={subtypes[name]} onChange={(e)=> onUpdate(name,{ color:e.target.value })} />
           <button className="px-1.5 py-0.5 bg-rose-600 text-white rounded" onClick={()=> onDelete(name)}>x</button>
@@ -602,6 +649,8 @@ function SubtypeManager({ subtypes, subtypeTypes, onAdd, onUpdate, onDelete }) {
         <select className="px-1 py-0.5 border rounded" value={newType} onChange={(e)=> setNewType(e.target.value)}>
           <option value="transition">Transition</option>
           <option value="effect">Effect</option>
+          <option value="clip">Clip</option>
+          <option value="remix">Remix</option>
         </select>
         <input type="color" className="h-6 w-10" value={newColor} onChange={(e)=> setNewColor(e.target.value)} />
         <button className="px-2 py-0.5 bg-slate-900 text-white rounded" onClick={()=> { if (!newName.trim()) return; onAdd(newName.trim(), newType, newColor); setNewName(''); }}>Add</button>
@@ -642,8 +691,9 @@ function GridBackground({ pxPerBeat }) {
 function ClipView({ clip, pxPerBeat, pxPerSec, selected, onSelect, onUpdate, onAddMarker, onUpdateMarker, onDeleteMarker, onHover, onClearHover, onSelectMarker, selectedMarkerRef, subtypeTypes, subtypes }) {
   const left = secToPx(clip.startSec, pxPerBeat);
   const width = Math.max(4, secToPx(clip.endSec - clip.startSec, pxPerBeat));
-  const stripe = REMIX_COLORS[clip.remixType] || '';
-  const bg = stripe ? `repeating-linear-gradient(45deg, ${clip.baseColor}, ${clip.baseColor} 12px, ${stripe} 12px, ${stripe} 24px)` : clip.baseColor;
+  const baseColor = subtypes[clip.subgenre] || clip.baseColor;
+  const stripe = subtypes[clip.remixType] || '';
+  const bg = stripe ? `repeating-linear-gradient(45deg, ${baseColor}, ${baseColor} 12px, ${stripe} 12px, ${stripe} 24px)` : baseColor;
 
   function startDrag(e) { e.stopPropagation(); onSelect(); const trackEl = document.getElementById(`track-${clip.track}`); if (!trackEl) return; const rect = trackEl.getBoundingClientRect(); const grab = e.clientX - rect.left - left; const onMove = (ev) => { if (ev.buttons !== 1) return cleanup(); const x = ev.clientX - rect.left - grab; const newStart = clamp(pxToSec(x, pxPerBeat), 0, rect.width); const dur = clip.endSec - clip.startSec; onUpdate({ startSec: newStart, endSec: newStart + dur }); }; const cleanup = () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', cleanup); }; window.addEventListener('mousemove', onMove); window.addEventListener('mouseup', cleanup); }
 
@@ -719,20 +769,17 @@ function Inspector({ clip, selectedMarkerRef, onChange, onDelete, onAddMarker, o
     <div className="mt-4 p-4 bg-white rounded shadow grid grid-cols-2 gap-6">
       <div>
         <div className="text-lg font-semibold mb-2">Clip Inspector</div>
-        <div className="grid grid-cols-2 gap-2 text-sm">
+        
+<div className="grid grid-cols-2 gap-2 text-sm">
           <label className="flex items-center gap-2 col-span-2"><span className="w-28">Name</span><input className="flex-1 px-2 py-1 border rounded" value={clip.name} onChange={(e)=> onChange({ name: e.target.value })} /></label>
           <label className="flex items-center gap-2"><span className="w-28">Deck</span><select className="flex-1 px-2 py-1 border rounded" value={clip.track} onChange={(e)=> onChange({ track: Number(e.target.value) })}>{Array.from({length:4}).map((_,i)=><option key={i} value={i}>Deck {i+1}</option>)}</select></label>
-          <label className="flex items-center gap-2"><span className="w-28">Start (s)</span><input type="number" className="flex-1 px-2 py-1 border rounded" value={fmtSec2(clip.startSec)} step={0.01} onChange={(e)=> onChange({ startSec: Number(e.target.value) || 0 })} /></label>
-          <label className="flex items-center gap-2"><span className="w-28">End (s)</span><input type="number" className="flex-1 px-2 py-1 border rounded" value={fmtSec2(clip.endSec)} step={0.01} onChange={(e)=> onChange({ endSec: Number(e.target.value) || 0 })} /></label>
-          <div className="col-span-2 text-xs text-slate-600">Duration: {fmtTime(clip.endSec - clip.startSec)} ({fmtSec2((clip.endSec-clip.startSec)/SECS_PER_BEAT)} beats)</div>
           <label className="flex items-center gap-2"><span className="w-28">Camelot</span><input className="flex-1 px-2 py-1 border rounded" value={clip.camelot||''} onChange={(e)=> onChange({ camelot: e.target.value })} /></label>
-          <label className="flex items-center gap-2"><span className="w-28">Genre</span><input className="flex-1 px-2 py-1 border rounded" value={clip.genre||''} onChange={(e)=> onChange({ genre: e.target.value })} /></label>
-          <label className="flex items-center gap-2"><span className="w-28">Subgenre</span><select className="flex-1 px-2 py-1 border rounded" value={clip.subgenre||''} onChange={(e)=> onChange({ subgenre: e.target.value, baseColor: SUBGENRE_COLORS[e.target.value] || clip.baseColor })}><option value="">(custom)</option>{Object.keys(SUBGENRE_COLORS).map(k=> <option key={k} value={k}>{k}</option>)}</select></label>
-          <label className="flex items-center gap-2"><span className="w-28">Base Color</span><input type="color" className="h-8 w-16" value={clip.baseColor} onChange={(e)=> onChange({ baseColor: e.target.value })} /></label>
-          <label className="flex items-center gap-2"><span className="w-28">Remix</span><select className="flex-1 px-2 py-1 border rounded" value={clip.remixType} onChange={(e)=> onChange({ remixType: e.target.value })}>{Object.keys(REMIX_COLORS).map(k => <option key={k} value={k}>{k}</option>)}</select></label>
+          <label className="flex items-center gap-2"><span className="w-28">Subgenre</span><select className="flex-1 px-2 py-1 border rounded" value={clip.subgenre||''} onChange={(e)=> onChange({ subgenre: e.target.value })}><option value="">(custom)</option>{Object.keys(subtypes).filter(k=> subtypeTypes[k]==='clip').map(k=> <option key={k} value={k}>{k}</option>)}</select></label>
+          <label className="flex items-center gap-2"><span className="w-28">Remix</span><select className="flex-1 px-2 py-1 border rounded" value={clip.remixType} onChange={(e)=> onChange({ remixType: e.target.value })}>{Object.keys(subtypes).filter(k=> subtypeTypes[k]==='remix').map(k => <option key={k} value={k}>{k}</option>)}</select></label>
           <label className="flex items-center gap-2"><span className="w-28">Energy</span><input type="number" className="flex-1 px-2 py-1 border rounded" value={clip.energy||5} onChange={(e)=> onChange({ energy: Math.max(1, Math.min(10, Math.round(Number(e.target.value)))) })} /></label>
         </div>
-        <div className="mt-3"><button className="px-3 py-1 bg-rose-600 text-white rounded" onClick={()=> onDelete()}>Delete Clip</button></div>
+        <div className="mt-3">
+<button className="px-3 py-1 bg-rose-600 text-white rounded" onClick={()=> onDelete()}>Delete Clip</button></div>
       </div>
 
       <div>
@@ -783,17 +830,6 @@ function MarkerEditor({ clip, selectedMarkerRef, onAddMarker, onUpdateMarker, on
         <label className="flex items-center gap-2"><span className="w-20">Color</span><input type="color" className="h-8 w-16" value={(draft.subtype && subtypes[draft.subtype]) || draft.color || '#000000'} disabled /></label>
         <label className="flex items-center gap-2"><span className="w-20">Start (s)</span><input type="number" step={0.01} className="flex-1 px-2 py-1 border rounded" value={fmtSec2(draft.startSec)} onChange={(e)=> updateField('startSec', Math.max(0, Number(e.target.value||0)))} /></label>
         <label className="flex items-center gap-2"><span className="w-20">End (s)</span><input type="number" step={0.01} className="flex-1 px-2 py-1 border rounded" value={draft.endSec == null ? '' : fmtSec2(draft.endSec)} onChange={(e)=> updateField('endSec', e.target.value === '' ? undefined : Math.max(0, Number(e.target.value)))} /></label>
-      </div>
-      <div className="mt-2 flex gap-2">
-        <button className="px-3 py-1 bg-slate-900 text-white rounded" onClick={()=> {
-          const m = { id: uid('m'), type: draft.type, subtype: draft.subtype, label: draft.label, details: draft.details || '', color: (draft.subtype && subtypes[draft.subtype]) || draft.color, startSec: Math.max(clip.startSec, Number(draft.startSec||clip.startSec)) };
-          if (draft.endSec != null) m.endSec = Math.max(m.startSec, Number(draft.endSec));
-          onAddMarker(m);
-        }}>+ Add Marker</button>
-
-        {selectedMarkerRef && <button className="px-3 py-1 bg-amber-600 text-white rounded" onClick={()=> { const sm = selectedMarkerRef; onUpdateMarker(sm.clipId, sm.markerId, { type: draft.type, subtype: draft.subtype, label: draft.label, details: draft.details || '', color: (draft.subtype && subtypes[draft.subtype]) || draft.color, startSec: Number(draft.startSec), endSec: draft.endSec != null ? Math.max(Number(draft.endSec), Number(draft.startSec||0)) : undefined }); }}>Update Marker</button>}
-
-        {selectedMarkerRef && <button className="px-3 py-1 bg-rose-600 text-white rounded" onClick={()=> { const sm = selectedMarkerRef; onDeleteMarker(sm.clipId, sm.markerId); }}>Delete Marker</button>}
       </div>
 
       <div className="mt-4">

--- a/dnbSetlist_V3I1.jsx
+++ b/dnbSetlist_V3I1.jsx
@@ -391,8 +391,8 @@ export default function App() {
   const [hover, setHover] = useState(null);
 
   return (
-    <div className="min-h-screen p-4 bg-slate-50 text-slate-900" ref={containerRef}>
-      <header className="flex items-center justify-between mb-3">
+    <div className="h-screen p-4 bg-slate-50 text-slate-900 flex flex-col overflow-hidden" ref={containerRef}>
+      <header className="flex items-center justify-between mb-3 flex-shrink-0">
         <h1 className="text-2xl font-bold">DnB Live Set Timeline (v3.2)</h1>
         <div className="flex gap-2 items-center">
           <input placeholder="YouTube or SoundCloud URL" id="media-url" className="px-2 py-1 border rounded" onBlur={(e)=> attachPlayer(e.target.value)} />
@@ -413,7 +413,7 @@ export default function App() {
         )}
       </header>
 
-      <div className="bg-white rounded p-3 shadow overflow-auto">
+      <div className="bg-white rounded p-3 shadow overflow-auto flex-1">
         {/* Big overall timeline integrated above the tracks */}
         <div style={{ width: timelineWidthPx }} className="mb-2">
           <BigTimelineHeader
@@ -461,7 +461,7 @@ export default function App() {
         </div>
       </div>
 
-      <div className="mb-3 flex items-center gap-2">
+      <div className="mb-3 flex items-center gap-2 flex-shrink-0">
         <Legend subtypes={subtypes} subtypeTypes={subtypeTypes} onAddSubtype={addSubtype} onUpdateSubtype={updateSubtype} onDeleteSubtype={deleteSubtype} />
       </div>
 
@@ -553,45 +553,33 @@ function Legend({ subtypes, subtypeTypes, onAddSubtype, onUpdateSubtype, onDelet
   const clipNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'clip');
   const remixNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'remix');
   const markerNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'transition' || subtypeTypes[k] === 'effect');
-  const markersByType = {
-    transition: markerNames.filter(n => (subtypeTypes[n] || 'transition') === 'transition'),
-    effect: markerNames.filter(n => (subtypeTypes[n] || 'transition') === 'effect')
-  };
+  const markerItems = markerNames.map(n => ({ name: n, type: subtypeTypes[n] || 'transition' }));
   return (
     <div className="relative w-full border rounded p-3">
       <button className="absolute top-2 right-2 text-xs underline" onClick={()=> setManage(m=>!m)}>{manage? 'Close':'Manage'}</button>
-      <div className="flex gap-6 items-start w-full justify-between text-sm">
-        <div>
+      <div className="flex items-start text-sm w-full">
+        <div className="pr-4">
           <div className="font-semibold">Clips (Subgenre)</div>
-          <div className="flex gap-2 mt-1">{clipNames.map(name => (
+          <div className="flex gap-2 mt-1 flex-wrap">{clipNames.map(name => (
             <div key={name} className="flex items-center gap-1"><div style={{width:12,height:12,background: subtypes[name],borderRadius:3}}/><div className="text-xs">{name}</div></div>
           ))}</div>
         </div>
-        <div className="flex-1">
+        <div className="px-4 border-l">
           <div className="font-semibold">Markers (Subtypes)</div>
-          <div className="mt-1">
-            {['transition','effect'].map(type => (
-              <div key={type} className="mb-2">
-                <div className="text-xs font-medium mb-1">{type[0].toUpperCase() + type.slice(1)}</div>
-                <div className="flex gap-3 flex-wrap items-center">
-                  {markersByType[type].map(name => (
-                    <div key={name} className="flex items-center gap-2 border px-2 py-1 rounded">
-                      {type === 'effect' ? (
-                        <div style={{ width: 0, height: 0, borderLeft: '7px solid transparent', borderRight: '7px solid transparent', borderBottom: `12px solid ${subtypes[name]}` }} />
-                      ) : (
-                        <div style={{width:14,height:14,background: subtypes[name],borderRadius:3}} />
-                      )}
-                      <div className="text-xs">{name}</div>
-                    </div>
-                  ))}
-                </div>
+          <div className="flex gap-3 flex-wrap items-center mt-1">
+            {markerItems.map(({name,type}) => (
+              <div key={name} className="flex items-center gap-2 border px-2 py-1 rounded">
+                {type === 'effect'
+                  ? <div style={{ width: 0, height: 0, borderLeft: '7px solid transparent', borderRight: '7px solid transparent', borderBottom: `12px solid ${subtypes[name]}` }} />
+                  : <div style={{width:14,height:14,background: subtypes[name],borderRadius:3}} />}
+                <div className="text-xs">{name}</div>
               </div>
             ))}
           </div>
         </div>
-        <div>
+        <div className="pl-4 border-l">
           <div className="font-semibold">Remix (Striped)</div>
-          <div className="flex gap-2 mt-1">{remixNames.map(name => (
+          <div className="flex gap-2 mt-1 flex-wrap">{remixNames.map(name => (
             <div key={name} className="flex items-center gap-1"><div style={{width:12,height:12,background: subtypes[name] ? `repeating-linear-gradient(45deg, ${subtypes[name]}, ${subtypes[name]} 6px, #fff 6px, #fff 12px)` : '#fff', border:'1px solid #ddd', borderRadius:3}}/><div className="text-xs">{name}</div></div>
           ))}</div>
         </div>
@@ -679,17 +667,20 @@ function SubtypeManager({ subtypes, subtypeTypes, onAdd, onUpdate, onDelete }) {
 
 function TrackRow({ children, trackIndex, widthPx, pxPerBeat, onAdd }) {
   return (
-    <div className="mb-3 flex items-start relative">
-      <div>
-        <div className="flex items-center gap-2 mb-1">
-          <div className="px-2 py-0.5 bg-slate-800 text-white rounded text-xs">Deck {trackIndex+1}</div>
-        </div>
-        <div id={`track-${trackIndex}`} className="relative h-28 rounded-xl border overflow-hidden" style={{ width: widthPx }}>
-          <GridBackground pxPerBeat={pxPerBeat} />
-          {children}
-        </div>
+    <div className="mb-3">
+      <div className="flex items-center gap-2 mb-1">
+        <div className="px-2 py-0.5 bg-slate-800 text-white rounded text-xs">Deck {trackIndex+1}</div>
       </div>
-      <button className="px-2 py-1 rounded bg-white border sticky top-2 right-2" onClick={onAdd}>+ Add Clip</button>
+      <div id={`track-${trackIndex}`} className="relative h-28 rounded-xl border overflow-hidden" style={{ width: widthPx }}>
+        <GridBackground pxPerBeat={pxPerBeat} />
+        {children}
+        <button
+          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-white border shadow flex items-center justify-center text-lg"
+          onClick={onAdd}
+        >
+          +
+        </button>
+      </div>
     </div>
   );
 }
@@ -845,9 +836,6 @@ function MarkerEditor({ clip, selectedMarkerRef, onAddMarker, onUpdateMarker, on
         </label>
         <label className="col-span-2 flex items-center gap-2"><span className="w-20">Label</span><input className="flex-1 px-2 py-1 border rounded" value={draft.label} onChange={(e)=> updateField('label', e.target.value)} /></label>
         <label className="col-span-2 flex items-center gap-2"><span className="w-20">Details</span><textarea rows={3} className="flex-1 px-2 py-1 border rounded" value={draft.details} onChange={(e)=> updateField('details', e.target.value)} /></label>
-        <label className="flex items-center gap-2"><span className="w-20">Color</span><input type="color" className="h-8 w-16" value={(draft.subtype && subtypes[draft.subtype]) || draft.color || '#000000'} disabled /></label>
-        <label className="flex items-center gap-2"><span className="w-20">Start (s)</span><input type="number" step={0.01} className="flex-1 px-2 py-1 border rounded" value={fmtSec2(draft.startSec)} onChange={(e)=> updateField('startSec', Math.max(0, Number(e.target.value||0)))} /></label>
-        <label className="flex items-center gap-2"><span className="w-20">End (s)</span><input type="number" step={0.01} className="flex-1 px-2 py-1 border rounded" value={draft.endSec == null ? '' : fmtSec2(draft.endSec)} onChange={(e)=> updateField('endSec', e.target.value === '' ? undefined : Math.max(0, Number(e.target.value)))} /></label>
       </div>
 
       <div className="mt-4">

--- a/dnbSetlist_V3I1.jsx
+++ b/dnbSetlist_V3I1.jsx
@@ -83,7 +83,6 @@ export default function App() {
   const [zoom, setZoom] = useState(1);
   const pxPerBeat = BASE_PX_PER_BEAT * zoom;
   const pxPerSec = pxPerBeat / SECS_PER_BEAT;
-  const TRACK_HEIGHT_PX = 112;
   const ROW_GAP_PX = 12;
 
   // subtype colors (user-manageable)
@@ -145,8 +144,24 @@ export default function App() {
   const lastRAF = useRef(null);
 
   useEffect(()=>{
-    const el = containerRef.current; if (!el) return; const onWheel = (e) => { if (e.ctrlKey) { e.preventDefault(); const factor = e.deltaY < 0 ? 1.12 : 1 / 1.12; setZoom(z=>clamp(z*factor, MIN_ZOOM, MAX_ZOOM)); } }; el.addEventListener('wheel', onWheel, { passive:false }); return ()=> el.removeEventListener('wheel', onWheel);
-  }, []);
+    const el = containerRef.current;
+    if (!el) return;
+    const onWheel = (e) => {
+      if (e.ctrlKey) {
+        e.preventDefault();
+        const rect = el.getBoundingClientRect();
+        const mouseX = e.clientX - rect.left;
+        const timeAtPointer = (el.scrollLeft + mouseX) / pxPerSec;
+        const factor = e.deltaY < 0 ? 1.12 : 1 / 1.12;
+        const newZoom = clamp(zoom * factor, MIN_ZOOM, MAX_ZOOM);
+        const newPxPerSec = (BASE_PX_PER_BEAT * newZoom) / SECS_PER_BEAT;
+        setZoom(newZoom);
+        el.scrollLeft = timeAtPointer * newPxPerSec - mouseX;
+      }
+    };
+    el.addEventListener('wheel', onWheel, { passive:false });
+    return ()=> el.removeEventListener('wheel', onWheel);
+  }, [zoom, pxPerSec]);
 
 
   // migrate any legacy marker beat fields into seconds relative to clip
@@ -173,8 +188,12 @@ export default function App() {
       const others = prev.filter((_,i)=>i!==idx);
       if (!noOverlap(updated, others)) return prev;
       if (patch.startSec != null && patch.startSec !== current.startSec) {
-        const delta = patch.startSec - current.startSec;
-        updated.markers = (current.markers||[]).map(m => ({ ...m, startSec: m.startSec + delta, endSec: m.endSec != null ? m.endSec + delta : undefined }));
+        const delta = updated.startSec - current.startSec;
+        updated.markers = (current.markers||[]).map(m => ({
+          ...m,
+          startSec: m.startSec + delta,
+          endSec: m.endSec != null ? m.endSec + delta : undefined
+        }));
       }
       const copy = [...prev]; copy[idx]=updated; return copy;
     });
@@ -413,7 +432,7 @@ export default function App() {
         )}
       </header>
 
-      <div className="bg-white rounded p-3 shadow overflow-auto flex-1">
+      <div className="bg-white rounded p-3 shadow overflow-x-auto overflow-y-hidden flex-1">
         {/* Big overall timeline integrated above the tracks */}
         <div style={{ width: timelineWidthPx }} className="mb-2">
           <BigTimelineHeader
@@ -454,7 +473,7 @@ export default function App() {
           </div>
 
           {/* Graph below deck 4 */}
-          <div className="mt-4">
+          <div className="mt-2">
             <h3 className="text-sm font-semibold mb-2">Energy & Camelot</h3>
             <Plots energySeries={energySeries} camelotSeries={camelotSeries} pxPerSec={pxPerSec} seconds={maxEnd} onHover={setHover} />
           </div>
@@ -671,11 +690,12 @@ function TrackRow({ children, trackIndex, widthPx, pxPerBeat, onAdd }) {
       <div className="flex items-center gap-2 mb-1">
         <div className="px-2 py-0.5 bg-slate-800 text-white rounded text-xs">Deck {trackIndex+1}</div>
       </div>
-      <div id={`track-${trackIndex}`} className="relative h-28 rounded-xl border overflow-hidden" style={{ width: widthPx }}>
+      <div id={`track-${trackIndex}`} className="relative h-24 rounded-xl border overflow-visible" style={{ width: widthPx }}>
         <GridBackground pxPerBeat={pxPerBeat} />
         {children}
         <button
-          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-white border shadow flex items-center justify-center text-lg"
+          className="sticky top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-white border shadow flex items-center justify-center text-lg"
+          style={{ left: 'calc(100% - 2rem)' }}
           onClick={onAdd}
         >
           +
@@ -713,7 +733,15 @@ function ClipView({ clip, pxPerBeat, pxPerSec, selected, onSelect, onUpdate, onA
   function startDragMarker(e, m, mode) {
     e.stopPropagation(); const startX = e.clientX; const startStartSec = m.startSec != null ? m.startSec : (clip.startSec); const startEndSec = m.endSec != null ? m.endSec : startStartSec; const onMove = (ev) => { if (ev.buttons !== 1) return cleanup(); const dxPx = ev.clientX - startX; const dxSec = pxToSec(dxPx, pxPerBeat); if (mode === 'body') { let ns = startStartSec + dxSec; let ne = startEndSec + dxSec; ns = clamp(ns, clip.startSec, clip.endSec); ne = clamp(ne, ns, clip.endSec); onUpdateMarker(m.id, { startSec: ns, endSec: m.endSec != null ? ne : undefined }); } else if (mode === 'left') { let ns = startStartSec + dxSec; ns = clamp(ns, clip.startSec, m.endSec != null ? m.endSec : startEndSec); onUpdateMarker(m.id, { startSec: ns }); } else if (mode === 'right') { let ne = startEndSec + dxSec; ne = clamp(ne, m.startSec != null ? m.startSec : clip.startSec, clip.endSec); onUpdateMarker(m.id, { endSec: ne }); } }; const cleanup = () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', cleanup); }; window.addEventListener('mousemove', onMove); window.addEventListener('mouseup', cleanup); }
 
-  function insertMarkerAtClick(e) { e.stopPropagation(); const rect = e.currentTarget.getBoundingClientRect(); const x = e.clientX - rect.left - left; const secRel = Math.max(0, pxToSec(x, pxPerBeat)); const defaultSubtype = Object.keys(subtypes).find(k => subtypeTypes[k] === 'transition') || Object.keys(subtypes)[0] || null; const m = { id: uid('m'), type: 'transition', subtype: defaultSubtype, label: '', details: '', startSec: clip.startSec + secRel }; onAddMarker(m); }
+  function insertMarkerAtClick(e) {
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const secRel = Math.max(0, pxToSec(x, pxPerBeat));
+    const defaultSubtype = Object.keys(subtypes).find(k => subtypeTypes[k] === 'transition') || Object.keys(subtypes)[0] || null;
+    const m = { id: uid('m'), type: 'transition', subtype: defaultSubtype, label: '', details: '', startSec: clip.startSec + secRel };
+    onAddMarker(m);
+  }
 
   function showClipHover(e) { const html = '<div><b>' + escapeHtml(clip.name) + '</b></div>' + '<div>' + escapeHtml(clip.genre||'') + (clip.subgenre ? ' / ' + escapeHtml(clip.subgenre) : '') + '</div>' + (clip.energy ? ('<div>Energy: ' + escapeHtml(String(clip.energy)) + '</div>') : '') + (clip.remixType && clip.remixType !== 'None' ? ('<div>Remix: ' + escapeHtml(clip.remixType) + '</div>') : ''); onHover({ x: e.clientX, y: e.clientY, html }); }
 

--- a/dnbSetlist_V3I1.jsx
+++ b/dnbSetlist_V3I1.jsx
@@ -551,37 +551,47 @@ function BigTimelineHeader({ widthPx, pxPerBeat, pxPerSec, clips, subtypes, onSe
 function Legend({ subtypes, subtypeTypes, onAddSubtype, onUpdateSubtype, onDeleteSubtype }) {
   const [manage, setManage] = useState(false);
   const clipNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'clip');
-  const markerNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'transition' || subtypeTypes[k] === 'effect');
   const remixNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'remix');
+  const markerNames = Object.keys(subtypes).filter(k => subtypeTypes[k] === 'transition' || subtypeTypes[k] === 'effect');
+  const markersByType = {
+    transition: markerNames.filter(n => (subtypeTypes[n] || 'transition') === 'transition'),
+    effect: markerNames.filter(n => (subtypeTypes[n] || 'transition') === 'effect')
+  };
   return (
     <div className="relative w-full border rounded p-3">
       <button className="absolute top-2 right-2 text-xs underline" onClick={()=> setManage(m=>!m)}>{manage? 'Close':'Manage'}</button>
-      <div className="text-sm flex flex-col gap-2">
+      <div className="flex gap-6 items-start w-full justify-between text-sm">
         <div>
           <div className="font-semibold">Clips (Subgenre)</div>
-          <div className="flex gap-2 mt-1 flex-wrap">{clipNames.map(name => (
+          <div className="flex gap-2 mt-1">{clipNames.map(name => (
             <div key={name} className="flex items-center gap-1"><div style={{width:12,height:12,background: subtypes[name],borderRadius:3}}/><div className="text-xs">{name}</div></div>
           ))}</div>
         </div>
-        <div className="border-t pt-2">
-          <div className="font-semibold">Markers</div>
-          <div className="mt-1 flex gap-3 flex-wrap items-center">{markerNames.map(name => {
-            const type = subtypeTypes[name];
-            return (
-              <div key={name} className="flex items-center gap-2 border px-2 py-1 rounded">
-                {type === 'effect' ? (
-                  <div style={{ width: 0, height: 0, borderLeft: '7px solid transparent', borderRight: '7px solid transparent', borderBottom: `12px solid ${subtypes[name]}` }} />
-                ) : (
-                  <div style={{width:14,height:14,background: subtypes[name],borderRadius:3}} />
-                )}
-                <div className="text-xs">{name}</div>
+        <div className="flex-1">
+          <div className="font-semibold">Markers (Subtypes)</div>
+          <div className="mt-1">
+            {['transition','effect'].map(type => (
+              <div key={type} className="mb-2">
+                <div className="text-xs font-medium mb-1">{type[0].toUpperCase() + type.slice(1)}</div>
+                <div className="flex gap-3 flex-wrap items-center">
+                  {markersByType[type].map(name => (
+                    <div key={name} className="flex items-center gap-2 border px-2 py-1 rounded">
+                      {type === 'effect' ? (
+                        <div style={{ width: 0, height: 0, borderLeft: '7px solid transparent', borderRight: '7px solid transparent', borderBottom: `12px solid ${subtypes[name]}` }} />
+                      ) : (
+                        <div style={{width:14,height:14,background: subtypes[name],borderRadius:3}} />
+                      )}
+                      <div className="text-xs">{name}</div>
+                    </div>
+                  ))}
+                </div>
               </div>
-            );
-          })}</div>
+            ))}
+          </div>
         </div>
-        <div className="border-t pt-2">
+        <div>
           <div className="font-semibold">Remix (Striped)</div>
-          <div className="flex gap-2 mt-1 flex-wrap">{remixNames.map(name => (
+          <div className="flex gap-2 mt-1">{remixNames.map(name => (
             <div key={name} className="flex items-center gap-1"><div style={{width:12,height:12,background: subtypes[name] ? `repeating-linear-gradient(45deg, ${subtypes[name]}, ${subtypes[name]} 6px, #fff 6px, #fff 12px)` : '#fff', border:'1px solid #ddd', borderRadius:3}}/><div className="text-xs">{name}</div></div>
           ))}</div>
         </div>


### PR DESCRIPTION
## Summary
- keep markers aligned to their clips while moving and refine deck layout with persistent Add Clip buttons
- allow deeper zoom-out with adaptive grids
- improve YouTube setlist import to alternate decks and infer clip lengths
- add clip clearing, subtype management, and consolidated marker legend

## Testing
- `node dnbSetlist_V3I1.jsx` *(fails: Unknown file extension ".jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68a5bb9e2cd08329807a27cfd8a68d91